### PR TITLE
[SCR-683] feat: Change category in manifest

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -9,7 +9,7 @@
   "editor": "Cozy",
   "vendor_link": "https://edocperso.fr/login",
   "categories": [
-    "others"
+    "clouds"
   ],
   "frequency": "weekly",
   "fields": {


### PR DESCRIPTION
Replace category in manifest for the konnector to display in "clouds and vaults" category in the store